### PR TITLE
Changed function setScene for Safari

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -36,7 +36,7 @@
 
   // OBS functions
   async function setScene(e) {
-    await obs.send('SetCurrentScene', { 'scene-name': e.currentTarget.innerText });
+    await obs.send('SetCurrentScene', { 'scene-name': e.currentTarget.textContent });
   }
 
   async function startStream() {


### PR DESCRIPTION
replaced "innerText" with "textContent" to make it work on iPads with Safari