### PR TITLE
Adapt font-size of scene buttons for mobile.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -373,15 +373,15 @@
               <!-- svelte-ignore a11y-missing-attribute -->
               {#if currentScene == sc.name}
                 <a class="tile is-child is-primary notification">
-                  <p class="title has-text-centered">{sc.name}</p>
+                  <p class="title has-text-centered is-size-6-mobile">{sc.name}</p>
                 </a>
               {:else if currentPreviewScene == sc.name}
                 <a on:click={setScene} class="tile is-child is-warning notification">
-                  <p class="title has-text-centered">{sc.name}</p>
+                  <p class="title has-text-centered is-size-6-mobile">{sc.name}</p>
                 </a>
               {:else}
                 <a on:click={isStudioMode ? setPreview : setScene} class="tile is-child is-info notification">
-                  <p class="title has-text-centered">{sc.name}</p>
+                  <p class="title has-text-centered is-size-6-mobile">{sc.name}</p>
                 </a>
               {/if}
             </div>


### PR DESCRIPTION
The smaller button size if for mobile (<768px) only. It lets me see more scene options without scrolling.

![improve-mobile](https://user-images.githubusercontent.com/1847734/94987035-b1557100-0563-11eb-8557-a444ab9f0283.jpg)
