### PR TITLE
Added "beforeunload" listener for disconnecting from websocket

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,7 @@
   const OBS_WEBSOCKET_LATEST_VERSION = '4.8.0'; // https://api.github.com/repos/Palakis/obs-websocket/releases/latest
 
   // Imports
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount } from 'svelte';
   import './style.scss';
   import { mdiFullscreen, mdiFullscreenExit, mdiBorderVertical, mdiArrowSplitHorizontal, mdiAccessPoint, mdiAccessPointOff, mdiRecord, mdiStop, mdiPause, mdiPlayPause } from '@mdi/js';
   import Icon from 'mdi-svelte';

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,7 +2,7 @@
   const OBS_WEBSOCKET_LATEST_VERSION = '4.8.0'; // https://api.github.com/repos/Palakis/obs-websocket/releases/latest
 
   // Imports
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
   import './style.scss';
   import { mdiFullscreen, mdiFullscreenExit, mdiBorderVertical, mdiArrowSplitHorizontal, mdiAccessPoint, mdiAccessPointOff, mdiRecord, mdiStop, mdiPause, mdiPlayPause } from '@mdi/js';
   import Icon from 'mdi-svelte';
@@ -65,6 +65,12 @@
       await connect();
     }
   });
+  
+  addEventListener("beforeunload", async () => {
+    if (!connected) return;
+    console.log("Disconnecting due to browser refreshing");
+    await disconnect();
+  })
 
   // State
   let connected,


### PR DESCRIPTION
Hi.
I've added the "beforeunload" listener in order to disconnect from websocket if the page is refreshed without disconnecting before (sometimes it can happen to me if I'm doing some debug).
Personally I don't like leaving connections opened.
I tried with "onDestroy" method but I couldn't make it work so I switched to addEventListener function.

Let me know