### PR TITLE
Save button space; Buffer Replay

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -163,6 +163,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "bzip22",
+      "name": "bzip22",
+      "avatar_url": "https://avatars.githubusercontent.com/u/21367547?v=4",
+      "profile": "https://github.com/bzip22",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OBS-web
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 #### The easiest way to control [OBS](https://obsproject.com/) remotely
@@ -91,6 +91,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/donahuetech"><img src="https://avatars.githubusercontent.com/u/28513975?v=4?s=100" width="100px;" alt="donahuetech"/><br /><sub><b>donahuetech</b></sub></a><br /><a href="https://github.com/Niek/obs-web/commits?author=donahuetech" title="Code">💻</a> <a href="#ideas-donahuetech" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/AshwinSatyawan"><img src="https://avatars.githubusercontent.com/u/40487239?v=4?s=100" width="100px;" alt="AshwinSatyawan"/><br /><sub><b>AshwinSatyawan</b></sub></a><br /><a href="https://github.com/Niek/obs-web/commits?author=AshwinSatyawan" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ewized"><img src="https://avatars.githubusercontent.com/u/1458852?v=4?s=100" width="100px;" alt="ewized"/><br /><sub><b>ewized</b></sub></a><br /><a href="https://github.com/Niek/obs-web/commits?author=ewized" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/bzip22"><img src="https://avatars.githubusercontent.com/u/21367547?v=4?s=100" width="100px;" alt="bzip22"/><br /><sub><b>bzip22</b></sub></a><br /><a href="https://github.com/Niek/obs-web/commits?author=bzip22" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,7 +25,12 @@
     mdiMotionPlayOutline,
     mdiMotionPlay,
     mdiContentSaveMoveOutline,
+<<<<<<< HEAD
+    mdiContentSaveCheckOutline,
+	mdiPlayBoxMultiple
+=======
     mdiContentSaveCheckOutline
+>>>>>>> 38c34b0 (Created framework for saving buffer replay (#431))
   } from '@mdi/js'
   import Icon from 'mdi-svelte'
   import { compareVersions } from 'compare-versions'
@@ -64,6 +69,16 @@
         .getElementById(navbar.dataset.target)
         .classList.toggle('is-active')
     })
+	
+	 // Listen for clicks outside the submenu to close it
+    document.addEventListener('click', (event) => {
+    const submenu = document.querySelector('.submenu');
+    const replayButton = document.querySelector('[title="Replay Options"]');
+		if (submenu && replayButton && !submenu.contains(event.target) && !replayButton.contains(event.target)) {
+		isReplayMenu = false;
+	  }
+    })
+	
 
     // Listen for fullscreen changes
     document.addEventListener('fullscreenchange', () => {
@@ -113,6 +128,10 @@
   let imageFormat = 'jpg'
   let isSaveReplay = false
   let isSaveReplayDisabled = false
+<<<<<<< HEAD
+  let isReplayMenu = false
+=======
+>>>>>>> 38c34b0 (Created framework for saving buffer replay (#431))
 
   $: isSceneOnTop
     ? window.localStorage.setItem('isSceneOnTop', 'true')
@@ -166,12 +185,45 @@
       }, 5000)
   }
 
+<<<<<<< HEAD
+  function toggleReplayMenu () {
+    isReplayMenu = !isReplayMenu
+  }
+
+=======
+>>>>>>> 38c34b0 (Created framework for saving buffer replay (#431))
   async function toggleReplay () {
     const data = await sendCommand('ToggleReplayBuffer')
     console.debug('ToggleReplayBuffer', data.outputActive)
     if (data.outputActive === undefined) {
       setReplayError('Replay buffer is not enabled.')
+<<<<<<< HEAD
+    } else { 
+		setTimeout(() => {
+			isReplaying = data.outputActive
+			isReplayMenu = false
+		},1800)
+	}
+  }
+
+  async function saveReplay() {
+    const data = await sendCommand('GetReplayBufferStatus')
+    console.debug('GetReplayBufferStatus', data.outputActive)
+    if (!data.outputActive) {
+      setReplayError('Replay buffer is not enabled.')
+      return
+    }
+    await sendCommand('SaveReplayBuffer')
+    isSaveReplayDisabled = true
+    isSaveReplay = true
+    setTimeout(() => {
+      isSaveReplay = false
+      isSaveReplayDisabled = false
+	  isReplayMenu = false
+    }, 2500)
+=======
     } else isReplaying = data.outputActive
+>>>>>>> 38c34b0 (Created framework for saving buffer replay (#431))
   }
 
   async function saveReplay() {
@@ -273,6 +325,8 @@
     const data = await sendCommand('GetVersion')
     const version = data.obsWebSocketVersion || ''
     console.log('OBS-websocket version:', version)
+    const replayBufferState = await sendCommand('GetReplayBufferStatus');
+    isReplaying = replayBufferState.outputActive;
     if (compareVersions(version, OBS_WEBSOCKET_LATEST_VERSION) < 0) {
       alert(
         'You are running an outdated OBS-websocket (version ' +
@@ -475,6 +529,21 @@
               </span>
             </button>
             <button
+              class:is-light={!isReplayMenu}
+              class="button is-link"
+              title="Replay Options"
+              on:click={toggleReplayMenu}
+            >
+              <span class="icon">
+                <Icon
+                  path={mdiPlayBoxMultiple}
+                />
+              </span>
+			  {#if replayError}<span>{replayError}</span>{/if}
+            </button>
+			{#if isReplayMenu}
+			<div class="submenu">
+            <button
               class:is-light={!isReplaying}
               class:is-danger={replayError}
               class="button is-link"
@@ -486,7 +555,6 @@
                   path={isReplaying ? mdiMotionPlayOutline : mdiMotionPlay}
                 />
               </span>
-              {#if replayError}<span>{replayError}</span>{/if}
             </button>
             <button
               class:is-light={!isSaveReplay}
@@ -504,8 +572,15 @@
                   path={isSaveReplay ? mdiContentSaveCheckOutline : mdiContentSaveMoveOutline}
                 />
               </span>
+<<<<<<< HEAD
+            </button>
+			</div>
+			{/if}
+			<span style="margin-right: 10px;"></span>
+=======
               {#if replayError}<span>{replayError}</span>{/if}
             </button>
+>>>>>>> 38c34b0 (Created framework for saving buffer replay (#431))
             <ProfileSelect />
             <SceneCollectionSelect />
             <button


### PR DESCRIPTION
Improved framework for Buffer usage
Created button Replay Options as a sub menu
Moved Toggle Replay Buffer and Save Replay Buffer to Replay Options
Added timeout(s) to sub-buttons to revert back to one nav bar object after use
Added event for clicks outside of submenu to hide Replay Options buttons after use
This should improve functionality without additional button clutter.

![image](https://github.com/user-attachments/assets/cbee5ee7-47b2-417f-92f2-73aac3bf0167)
onclick
![image](https://github.com/user-attachments/assets/3f9ebbe6-f266-4a59-b704-4e96b99b2318)
