### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,22 +11,22 @@
         "@fullhuman/postcss-purgecss": "^7.0.2",
         "@mdi/js": "^7.4.47",
         "@sveltejs/adapter-static": "^3.0.10",
-        "@sveltejs/kit": "^2.46.4",
+        "@sveltejs/kit": "^2.47.2",
         "bulma": "^1.0.4",
         "compare-versions": "^6.1.1",
-        "eslint": "^9.37.0",
+        "eslint": "^9.38.0",
         "eslint-plugin-html": "^8.1.3",
-        "eslint-plugin-svelte": "^3.12.4",
+        "eslint-plugin-svelte": "^3.12.5",
         "mdi-svelte": "^1.1.2",
         "neostandard": "^0.12.2",
         "obs-websocket-js": "^5.0.6",
         "sass": "^1.93.2",
-        "svelte": "^5.39.2",
-        "svelte-eslint-parser": "^1.3.3",
+        "svelte": "^5.41.1",
+        "svelte-eslint-parser": "^1.4.0",
         "svelte-preprocess": "^6.0.3",
         "terser": "^5.44.0",
         "typescript": "^5.9.3",
-        "vite": "^7.1.9"
+        "vite": "^7.1.11"
       }
     },
     "node_modules/@emnapi/core": {
@@ -548,13 +548,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -563,9 +563,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -613,9 +613,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -626,9 +626,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1564,9 +1564,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.46.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.46.4.tgz",
-      "integrity": "sha512-J1fd80WokLzIm6EAV7z7C2+/C02qVAX645LZomARARTRJkbbJSY1Jln3wtBZYibUB8c9/5Z6xqLAV39VdbtWCQ==",
+      "version": "2.47.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.47.2.tgz",
+      "integrity": "sha512-mbUomaJTiADTrq6GT4ZvQ7v1rs0S+wXGMzrjFwjARAKMEF8FpOUmz2uEJ4M9WMJMQOXCMHpKFzJfdjo9O7M22A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3230,25 +3230,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.1",
         "@eslint/core": "^0.16.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.37.0",
+        "@eslint/js": "9.38.0",
         "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -3557,9 +3556,9 @@
       }
     },
     "node_modules/eslint-plugin-svelte": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.12.4.tgz",
-      "integrity": "sha512-hD7wPe+vrPgx3U2X2b/wyTMtWobm660PygMGKrWWYTc9lvtY8DpNFDaU2CJQn1szLjGbn/aJ3g8WiXuKakrEkw==",
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.12.5.tgz",
+      "integrity": "sha512-4KRG84eAHQfYd9OjZ1K7sCHy0nox+9KwT+s5WCCku3jTim5RV4tVENob274nCwIaApXsYPKAUAZFBxKZ3Wyfjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3572,7 +3571,7 @@
         "postcss-load-config": "^3.1.4",
         "postcss-safe-parser": "^7.0.0",
         "semver": "^7.6.3",
-        "svelte-eslint-parser": "^1.3.0"
+        "svelte-eslint-parser": "^1.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6432,9 +6431,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.39.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.39.2.tgz",
-      "integrity": "sha512-x4Me4TgiNprpLugcXyKbcGQhHdjWpITZzSeegv3jjIyA4jObVKBhNchGGDv257Eeolg3vUUSa4n2HGFMYNaPvg==",
+      "version": "5.41.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.41.1.tgz",
+      "integrity": "sha512-0a/huwc8e2es+7KFi70esqsReRfRbrT8h1cJSY/+z1lF0yKM6TT+//HYu28Yxstr50H7ifaqZRDGd0KuKDxP7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6458,9 +6457,9 @@
       }
     },
     "node_modules/svelte-eslint-parser": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.3.3.tgz",
-      "integrity": "sha512-oTrDR8Z7Wnguut7QH3YKh7JR19xv1seB/bz4dxU5J/86eJtZOU4eh0/jZq4dy6tAlz/KROxnkRQspv5ZEt7t+Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.4.0.tgz",
+      "integrity": "sha512-fjPzOfipR5S7gQ/JvI9r2H8y9gMGXO3JtmrylHLLyahEMquXI0lrebcjT+9/hNgDej0H7abTyox5HpHmW1PSWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6472,7 +6471,8 @@
         "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+        "pnpm": "10.18.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ota-meshi"
@@ -6894,9 +6894,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
-      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,21 +12,21 @@
     "@fullhuman/postcss-purgecss": "^7.0.2",
     "@mdi/js": "^7.4.47",
     "@sveltejs/adapter-static": "^3.0.10",
-    "@sveltejs/kit": "^2.46.4",
+    "@sveltejs/kit": "^2.47.2",
     "bulma": "^1.0.4",
     "compare-versions": "^6.1.1",
-    "eslint": "^9.37.0",
+    "eslint": "^9.38.0",
     "eslint-plugin-html": "^8.1.3",
-    "eslint-plugin-svelte": "^3.12.4",
+    "eslint-plugin-svelte": "^3.12.5",
     "mdi-svelte": "^1.1.2",
     "neostandard": "^0.12.2",
     "obs-websocket-js": "^5.0.6",
     "sass": "^1.93.2",
-    "svelte": "^5.39.2",
-    "svelte-eslint-parser": "^1.3.3",
+    "svelte": "^5.41.1",
+    "svelte-eslint-parser": "^1.4.0",
     "svelte-preprocess": "^6.0.3",
     "terser": "^5.44.0",
     "typescript": "^5.9.3",
-    "vite": "^7.1.9"
+    "vite": "^7.1.11"
   }
 }


### PR DESCRIPTION
Updated the following dependencies:
- @sveltejs/kit: ^2.46.4 → ^2.47.2
- eslint: ^9.37.0 → ^9.38.0
- eslint-plugin-svelte: ^3.12.4 → ^3.12.5
- svelte: ^5.39.2 → ^5.41.1
- svelte-eslint-parser: ^1.3.3 → ^1.4.0
- vite: ^7.1.9 → ^7.1.11

Verified dev environment runs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)