### PR TITLE
chore: update GitHub Actions dependencies to latest versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
           path: v5
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 


### PR DESCRIPTION
Updated actions/setup-node from v5 to v6 to use the latest version with node24 support. All other actions were already on their latest versions:
- actions/checkout@v5 (latest)
- peaceiris/actions-gh-pages@v4 (latest)
- docker/setup-qemu-action@v3 (latest)
- docker/setup-buildx-action@v3 (latest)
- docker/login-action@v3 (latest)
- docker/build-push-action@v6 (latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)