### PR TITLE
Add OBS audio meter

### DIFF
--- a/src/LocalBrowserMicTest.svelte
+++ b/src/LocalBrowserMicTest.svelte
@@ -1,0 +1,200 @@
+<script>
+  import { onDestroy } from 'svelte'
+
+  let isRunning = false
+  let isListening = false
+  let level = 0
+  let errorMessage = ''
+  let stream
+  let audioContext
+  let source
+  let analyser
+  let gain
+  let audioData = new Uint8Array(0)
+  let animationFrame
+
+  $: if (gain) {
+    gain.gain.value = isListening ? 1 : 0
+  }
+
+  onDestroy(() => {
+    stopMicTest()
+  })
+
+  async function startMicTest () {
+    if (isRunning) return
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      errorMessage = 'Browser mic access is not available.'
+      return
+    }
+
+    errorMessage = ''
+
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+        video: false
+      })
+
+      const AudioContextConstructor = window.AudioContext || window.webkitAudioContext
+      if (!AudioContextConstructor) {
+        throw new Error('Web Audio is not available in this browser.')
+      }
+
+      audioContext = new AudioContextConstructor()
+      if (audioContext.state === 'suspended') {
+        await audioContext.resume()
+      }
+
+      source = audioContext.createMediaStreamSource(stream)
+      analyser = audioContext.createAnalyser()
+      gain = audioContext.createGain()
+
+      analyser.fftSize = 2048
+      analyser.smoothingTimeConstant = 0.85
+      gain.gain.value = isListening ? 1 : 0
+
+      source.connect(analyser)
+      source.connect(gain)
+      gain.connect(audioContext.destination)
+
+      audioData = new Uint8Array(analyser.fftSize)
+      isRunning = true
+      updateMicLevel()
+    } catch (error) {
+      stopMicTest()
+      errorMessage = error.message || 'Could not start the mic test.'
+    }
+  }
+
+  function stopMicTest () {
+    if (animationFrame) cancelAnimationFrame(animationFrame)
+    animationFrame = undefined
+
+    stream?.getTracks().forEach(track => track.stop())
+    stream = undefined
+
+    source?.disconnect()
+    analyser?.disconnect()
+    gain?.disconnect()
+
+    source = undefined
+    analyser = undefined
+    gain = undefined
+    audioData = new Uint8Array(0)
+
+    if (audioContext && audioContext.state !== 'closed') {
+      audioContext.close().catch(error => {
+        console.debug('Audio context close failed', error)
+      })
+    }
+    audioContext = undefined
+
+    isRunning = false
+    level = 0
+  }
+
+  function updateMicLevel () {
+    if (!isRunning || !analyser) return
+
+    analyser.getByteTimeDomainData(audioData)
+    level = getRmsLevel(audioData)
+    animationFrame = requestAnimationFrame(updateMicLevel)
+  }
+
+  function getRmsLevel (data) {
+    if (!data.length) return 0
+
+    let sumSquares = 0
+    for (const value of data) {
+      const sample = (value - 128) / 128
+      sumSquares += sample * sample
+    }
+
+    const rms = Math.sqrt(sumSquares / data.length)
+    return Math.round(Math.max(0, Math.min(100, Math.sqrt(rms) * 140)))
+  }
+</script>
+
+<section class="local-mic-section">
+  <div class="section-heading">
+    <h2 class="title is-5">Local Browser Mic Test</h2>
+    <div class="buttons">
+      <button
+        class="button is-success"
+        type="button"
+        disabled={isRunning}
+        on:click={startMicTest}
+      >
+        Start
+      </button>
+      <button
+        class="button"
+        type="button"
+        disabled={!isRunning}
+        on:click={stopMicTest}
+      >
+        Stop
+      </button>
+    </div>
+  </div>
+
+  <label class="checkbox listen-control">
+    <input type="checkbox" bind:checked={isListening} />
+    Listen locally
+  </label>
+
+  <div
+    class="meter-track"
+    role="meter"
+    aria-label="Local browser mic level"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    aria-valuenow={level}
+  >
+    <span class="meter-fill" style:width="{level}%"></span>
+  </div>
+
+  {#if errorMessage}
+    <p class="help is-danger">{errorMessage}</p>
+  {/if}
+</section>
+
+<style>
+  .local-mic-section {
+    margin-bottom: 2rem;
+  }
+
+  .section-heading {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: space-between;
+  }
+
+  .section-heading .title {
+    margin-bottom: 0;
+  }
+
+  .listen-control {
+    display: inline-flex;
+    gap: .5rem;
+    margin-bottom: .75rem;
+  }
+
+  .meter-track {
+    background: #dbdbdb;
+    border-radius: 4px;
+    height: .75rem;
+    overflow: hidden;
+  }
+
+  .meter-fill {
+    background: linear-gradient(90deg, #23d160 0%, #ffdd57 70%, #ff3860 100%);
+    display: block;
+    height: 100%;
+    transition: width 60ms linear;
+  }
+</style>

--- a/src/OBSAudioMeter.svelte
+++ b/src/OBSAudioMeter.svelte
@@ -1,0 +1,148 @@
+<script>
+  import { onDestroy, onMount } from 'svelte'
+  import { obs } from './obs.js'
+
+  const FLOOR_DB = -60
+
+  let audioInputs = []
+  let pendingAudioInputs = []
+  let animationFrame
+
+  onMount(() => {
+    obs.on('InputVolumeMeters', onInputVolumeMeters)
+  })
+
+  onDestroy(() => {
+    obs.off('InputVolumeMeters', onInputVolumeMeters)
+    if (animationFrame) cancelAnimationFrame(animationFrame)
+  })
+
+  function onInputVolumeMeters (data) {
+    pendingAudioInputs = Array.isArray(data?.inputs)
+      ? data.inputs.map(normalizeAudioInput)
+      : []
+
+    if (!animationFrame) {
+      animationFrame = requestAnimationFrame(() => {
+        audioInputs = pendingAudioInputs
+        animationFrame = undefined
+      })
+    }
+  }
+
+  function normalizeAudioInput (input, index) {
+    const name = typeof input?.inputName === 'string'
+      ? input.inputName
+      : `Input ${index + 1}`
+
+    return {
+      id: input?.inputUuid || name,
+      name,
+      level: Math.round(getInputLevel(input))
+    }
+  }
+
+  function getInputLevel (input) {
+    const dbLevel = getMaxNumber(input?.inputLevelsDb)
+    if (Number.isFinite(dbLevel)) {
+      return clampPercent(((dbLevel - FLOOR_DB) / Math.abs(FLOOR_DB)) * 100)
+    }
+
+    const linearLevel = getMaxNumber(input?.inputLevelsMul)
+    if (Number.isFinite(linearLevel)) {
+      return clampPercent(Math.sqrt(Math.max(0, linearLevel)) * 100)
+    }
+
+    return 0
+  }
+
+  function getMaxNumber (value) {
+    if (Array.isArray(value)) {
+      return value.reduce(
+        (max, item) => Math.max(max, getMaxNumber(item)),
+        Number.NEGATIVE_INFINITY
+      )
+    }
+
+    const number = Number(value)
+    return Number.isFinite(number) ? number : Number.NEGATIVE_INFINITY
+  }
+
+  function clampPercent (value) {
+    return Math.max(0, Math.min(100, value))
+  }
+</script>
+
+<section class="audio-meter-section">
+  <h2 class="title is-5">OBS Audio Meter</h2>
+
+  {#if audioInputs.length}
+    <div class="meter-list">
+      {#each audioInputs as input (input.id)}
+        <div class="meter-row">
+          <div class="meter-heading">
+            <span class="meter-name">{input.name}</span>
+            <span class="meter-value">{input.level}%</span>
+          </div>
+          <div
+            class="meter-track"
+            role="meter"
+            aria-label="{input.name} level"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow={input.level}
+          >
+            <span class="meter-fill" style:width="{input.level}%"></span>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <p class="help">No active OBS audio inputs detected.</p>
+  {/if}
+</section>
+
+<style>
+  .audio-meter-section {
+    margin-bottom: 2rem;
+  }
+
+  .meter-list {
+    display: grid;
+    gap: .75rem;
+  }
+
+  .meter-heading {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-bottom: .25rem;
+  }
+
+  .meter-name {
+    font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .meter-value {
+    font-variant-numeric: tabular-nums;
+  }
+
+  .meter-track {
+    background: #dbdbdb;
+    border-radius: 4px;
+    height: .75rem;
+    overflow: hidden;
+  }
+
+  .meter-fill {
+    background: linear-gradient(90deg, #23d160 0%, #ffdd57 70%, #ff3860 100%);
+    display: block;
+    height: 100%;
+    transition: width 60ms linear;
+  }
+</style>

--- a/src/ProgramPreview.svelte
+++ b/src/ProgramPreview.svelte
@@ -13,6 +13,10 @@
   let screenshotInterval
   let transitions = []
   // let currentTransition = ''
+  const screenshotOptions = {
+    imageWidth: 960,
+    imageHeight: 540
+  }
 
   onMount(async () => {
     let data
@@ -76,8 +80,7 @@
     let data = await sendCommand('GetSourceScreenshot', {
       sourceName: programScene,
       imageFormat,
-      imageWidth: 960,
-      imageHeight: 540
+      ...screenshotOptions
     })
     if (data && data.imageData && program) {
       program.src = data.imageData
@@ -89,8 +92,7 @@
         data = await sendCommand('GetSourceScreenshot', {
           sourceName: previewScene,
           imageFormat,
-          imageWidth: 960,
-          imageHeight: 540
+          ...screenshotOptions
         })
       }
       if (data && data.imageData && preview) {

--- a/src/obs.js
+++ b/src/obs.js
@@ -1,7 +1,8 @@
-import OBSWebSocket from 'obs-websocket-js'
+import OBSWebSocket, { EventSubscription } from 'obs-websocket-js'
 
 export const obs = new OBSWebSocket()
 export const DEFAULT_OBS_ADDRESS = 'ws://localhost:4455'
+export { EventSubscription }
 
 export function parseObsConnectionDetails (
   inputAddress,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,15 +32,18 @@
 
   import {
     DEFAULT_OBS_ADDRESS,
+    EventSubscription,
     obs,
     parseObsConnectionDetails,
     sendCommand
   } from '../obs.js'
+  import OBSAudioMeter from '../OBSAudioMeter.svelte'
   import ProgramPreview from '../ProgramPreview.svelte'
   import SceneSwitcher from '../SceneSwitcher.svelte'
   import SourceSwitcher from '../SourceSwitcher.svelte'
   import ProfileSelect from '../ProfileSelect.svelte'
   import SceneCollectionSelect from '../SceneCollectionSelect.svelte'
+  import LocalBrowserMicTest from '../LocalBrowserMicTest.svelte'
 
   onMount(async () => {
     if ('serviceWorker' in navigator) {
@@ -371,7 +374,11 @@
       await disconnect()
       const { obsWebSocketVersion, negotiatedRpcVersion } = await obs.connect(
         address,
-        password
+        password,
+        {
+          eventSubscriptions:
+            EventSubscription.All | EventSubscription.InputVolumeMeters
+        }
       )
       console.log(
         `Connected to obs-websocket version ${obsWebSocketVersion} (using RPC ${negotiatedRpcVersion})`
@@ -686,6 +693,7 @@
       {#if !isSceneOnTop}
         <ProgramPreview {imageFormat} />
       {/if}
+      <OBSAudioMeter />
       {#each scenes as scene}
         {#if scene.sceneName.indexOf('(switch)') > 0}
           <SourceSwitcher
@@ -831,6 +839,11 @@
         <a href="/v4/">archived OBS-web v4</a> page.
       </p>
     {/if}
+
+    <details class="local-mic-test-details">
+      <summary>Local Browser Mic Test</summary>
+      <LocalBrowserMicTest />
+    </details>
   </div>
 </section>
 
@@ -846,3 +859,14 @@
     </p>
   </div>
 </footer>
+
+<style>
+  .local-mic-test-details {
+    margin-top: 1rem;
+  }
+
+  .local-mic-test-details summary {
+    cursor: pointer;
+    font-size: .875rem;
+  }
+</style>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,16 @@
-import { viteConfig } from './svelte.config.js'
+import { sveltekit } from '@sveltejs/kit/vite'
 
-export default viteConfig
+const allowedHosts = (process.env.VITE_ALLOWED_HOSTS || '')
+  .split(',')
+  .map(host => host.trim())
+  .filter(Boolean)
+
+export default {
+  plugins: [sveltekit()],
+  server: {
+    allowedHosts: ['localhost', '127.0.0.1', ...allowedHosts]
+  },
+  preview: {
+    allowedHosts: ['localhost', '127.0.0.1', ...allowedHosts]
+  }
+}


### PR DESCRIPTION
## Contributor note

This PR was built with AI assistance. I’m not a regular contributor to the project, but I thought this feature could be useful and validated the change with the checks below.

Please treat this as a proposed implementation rather than a demand to merge as-is. I’m happy to make changes if there’s a cleaner or more project-appropriate way to do it.

## Summary
- Add an OBS websocket-driven audio meter for active input volume levels.
- Keep the local browser mic test available behind a collapsed diagnostics section.
- Preserve the fixed 960x540 preview screenshot sizing through shared screenshot options so the program/preview images keep the cleaner 16:9 layout.
- Make extra Vite dev/preview allowed hosts configurable through `VITE_ALLOWED_HOSTS` instead of hardcoding a local machine name.

## Validation
- `npm run lint`
- `npm run build` passes. The build also prints existing Sass deprecation warnings from Bulma dependency code.
- Scanned the branch diff for local machine names and tool/vendor markers.