### PR TITLE
chore(deps): ignore TypeScript 7 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "typescript"
+        versions: ["7.x"]


### PR DESCRIPTION
## Summary

- ignore TypeScript 7.x updates from Dependabot
- keep TypeScript 6 patch and minor updates enabled

TypeScript 7 currently breaks the Svelte checking and linting toolchain, as documented on #665 and in sveltejs/language-tools#3063.

## Validation

- parsed `.github/dependabot.yml` as YAML
- verified the npm updater resolves `typescript` with `versions: ["7.x"]`
- `git diff --check`