### PR TITLE
Fix Program/Preview bugs: screenshot race, listener leaks, dead code

### DIFF
--- a/src/ProgramPreview.svelte
+++ b/src/ProgramPreview.svelte
@@ -149,7 +149,6 @@
 
         if (programData && programData.imageData && program) {
           program.src = programData.imageData
-          program.className = ''
         }
 
         if (isStudioMode) {

--- a/src/ProgramPreview.svelte
+++ b/src/ProgramPreview.svelte
@@ -36,66 +36,131 @@
 
   onDestroy(() => {
     clearInterval(screenshotInterval)
+    obs.off('StudioModeStateChanged', handleStudioModeStateChanged)
+    obs.off('CurrentPreviewSceneChanged', handleCurrentPreviewSceneChanged)
+    obs.off('CurrentProgramSceneChanged', handleCurrentProgramSceneChanged)
+    obs.off('SceneNameChanged', handleSceneNameChanged)
+    obs.off('TransitionListChanged', handleTransitionListChanged)
   })
 
   $: if (programScene || previewScene) {
     getScreenshot()
   }
 
-  obs.on('StudioModeStateChanged', async (data) => {
+  // Named handlers (not inline arrow functions passed straight to obs.on)
+  // so onDestroy can remove the exact same references via obs.off() - same
+  // pattern already used in AudioMixer.svelte/SceneItemsPanel.svelte. This
+  // component lives inside +page.svelte's `{#if connected}` block, so it's
+  // destroyed and recreated on every disconnect/reconnect - without this
+  // cleanup, every reconnect stacks another full set of listeners onto the
+  // long-lived `obs` singleton, each one firing (redundantly, but not
+  // harmlessly - see getScreenshot() above) on every subsequent event.
+  function handleStudioModeStateChanged (data) {
     console.log('StudioModeStateChanged', data.studioModeEnabled)
     isStudioMode = data.studioModeEnabled
     if (isStudioMode) {
       previewScene = programScene
     }
-  })
+  }
 
-  obs.on('CurrentPreviewSceneChanged', async (data) => {
+  function handleCurrentPreviewSceneChanged (data) {
     console.log('CurrentPreviewSceneChanged', data.sceneName)
     previewScene = data.sceneName
-  })
+  }
 
-  obs.on('CurrentProgramSceneChanged', async (data) => {
+  function handleCurrentProgramSceneChanged (data) {
     console.log('CurrentProgramSceneChanged', data.sceneName)
     programScene = data.sceneName
-  })
+  }
 
-  obs.on('SceneNameChanged', async (data) => {
+  function handleSceneNameChanged (data) {
     if (data.oldSceneName === programScene) programScene = data.sceneName
     if (data.oldSceneName === previewScene) previewScene = data.sceneName
-  })
+  }
 
   // TODO: does not exist???
-  obs.on('TransitionListChanged', async (data) => {
+  function handleTransitionListChanged (data) {
     console.log('TransitionListChanged', data)
     transitions = data.transitions || []
-  })
+  }
+
+  obs.on('StudioModeStateChanged', handleStudioModeStateChanged)
+  obs.on('CurrentPreviewSceneChanged', handleCurrentPreviewSceneChanged)
+  obs.on('CurrentProgramSceneChanged', handleCurrentProgramSceneChanged)
+  obs.on('SceneNameChanged', handleSceneNameChanged)
+  obs.on('TransitionListChanged', handleTransitionListChanged)
+
+  // Guards against unbounded overlapping calls: getScreenshot() is driven
+  // by both a 1s setInterval AND the reactive statement below (which
+  // re-fires on every programScene/previewScene change, e.g. every time a
+  // preview scene gets picked). Each call awaits up to two sequential
+  // GetSourceScreenshot round-trips - once Studio Mode is on and a
+  // different preview scene is selected, that's roughly double the
+  // per-call latency of the single-scene case. Without this guard, a slow
+  // call (OBS busy rendering/encoding while also streaming, or just normal
+  // network latency) could still be in flight when the next interval tick
+  // - or several rapid preview-scene picks - fire more calls on top of it;
+  // with no ordering guarantee on which response lands last, an older,
+  // slower response could overwrite a newer image with a stale one, and
+  // under sustained overlap this can make the image appear to stop
+  // updating rather than just occasionally flicker. `screenshotPending`
+  // coalesces any calls that arrive while one's already running into a
+  // single extra pass immediately after, instead of just dropping them (so
+  // a rapid preview-scene switch never has to wait a full 1s for the next
+  // interval tick to catch up).
+  let screenshotInFlight = false
+  let screenshotPending = false
 
   async function getScreenshot () {
     if (!programScene) return
-    let data = await sendCommand('GetSourceScreenshot', {
-      sourceName: programScene,
-      imageFormat,
-      imageWidth: 960,
-      imageHeight: 540
-    })
-    if (data && data.imageData && program) {
-      program.src = data.imageData
-      program.className = ''
+    if (screenshotInFlight) {
+      screenshotPending = true
+      return
     }
+    screenshotInFlight = true
+    try {
+      do {
+        screenshotPending = false
 
-    if (isStudioMode) {
-      if (previewScene !== programScene) {
-        data = await sendCommand('GetSourceScreenshot', {
-          sourceName: previewScene,
-          imageFormat,
-          imageWidth: 960,
-          imageHeight: 540
-        })
-      }
-      if (data && data.imageData && preview) {
-        preview.src = data.imageData
-      }
+        // Fetched in parallel (not sequentially) - halves the per-call
+        // latency whenever both are needed, making overlap less likely in
+        // the first place. previewScene is only fetched separately when it
+        // actually differs from programScene (and is set at all) - same
+        // "reuse the program frame for an identical preview" optimization
+        // as before, now via wantsPreview instead of reassigning a shared
+        // `data` variable.
+        const wantsPreview = isStudioMode && previewScene && previewScene !== programScene
+        const [programData, previewData] = await Promise.all([
+          sendCommand('GetSourceScreenshot', {
+            sourceName: programScene,
+            imageFormat,
+            imageWidth: 960,
+            imageHeight: 540
+          }),
+          wantsPreview
+            ? sendCommand('GetSourceScreenshot', {
+              sourceName: previewScene,
+              imageFormat,
+              imageWidth: 960,
+              imageHeight: 540
+            })
+            : Promise.resolve(null)
+        ])
+
+        if (programData && programData.imageData && program) {
+          program.src = programData.imageData
+          program.className = ''
+        }
+
+        if (isStudioMode) {
+          const activePreviewData = wantsPreview ? previewData : programData
+          if (activePreviewData && activePreviewData.imageData && preview) {
+            preview.src = activePreviewData.imageData
+          }
+        }
+      } while (screenshotPending)
+    } finally {
+      screenshotInFlight = false
     }
   }
 </script>
@@ -103,7 +168,10 @@
 <div class="columns is-centered is-vcentered has-text-centered">
   {#if isStudioMode}
     <div class="column">
-      <img bind:this={preview} class="has-background-dark" alt="Preview" />
+      <div class="preview-pane">
+        <div class="pane-label pane-label-preview">Preview</div>
+        <img bind:this={preview} class="has-background-dark pane-image pane-image-preview" alt="Preview" />
+      </div>
     </div>
     <div class="column is-narrow">
       {#each transitions as transition}
@@ -115,8 +183,48 @@
         >{transition.transitionName}</button>
       {/each}
     </div>
+    <div class="column">
+      <div class="program-pane">
+        <div class="pane-label pane-label-program">Program (Live)</div>
+        <img bind:this={program} class="pane-image pane-image-program" alt="Program" />
+      </div>
+    </div>
+  {:else}
+    <div class="column">
+      <img bind:this={program} alt="Program"/>
+    </div>
   {/if}
-  <div class="column">
-    <img bind:this={program} alt="Program"/>
-  </div>
 </div>
+
+<style>
+  .pane-label {
+    border-radius: 4px 4px 0 0;
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    padding: 0.35rem 0;
+    text-transform: uppercase;
+  }
+  .pane-label-preview {
+    background: hsl(140, 70%, 33%);
+    color: white;
+  }
+  .pane-label-program {
+    background: hsl(0, 75%, 45%);
+    color: white;
+  }
+  .pane-image {
+    display: block;
+    width: 100%;
+  }
+  .pane-image-preview {
+    border: 3px solid hsl(140, 70%, 33%);
+    border-radius: 0 0 4px 4px;
+    border-top: none;
+  }
+  .pane-image-program {
+    border: 3px solid hsl(0, 75%, 45%);
+    border-radius: 0 0 4px 4px;
+    border-top: none;
+  }
+</style>

--- a/src/SceneSwitcher.svelte
+++ b/src/SceneSwitcher.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount } from 'svelte'
+  import { onDestroy, onMount } from 'svelte'
   import { obs, sendCommand } from './obs.js'
   import SourceButton from './SourceButton.svelte'
 
@@ -30,31 +30,42 @@
     }
   })
 
-  obs.on('StudioModeStateChanged', async (data) => {
+  // Named handlers (not inline arrow functions passed straight to obs.on)
+  // so onDestroy can remove the exact same references via obs.off() - same
+  // pattern already used in AudioMixer.svelte/SceneItemsPanel.svelte. This
+  // component lives inside +page.svelte's `{#if connected}` block, so it's
+  // destroyed and recreated on every disconnect/reconnect - without this
+  // cleanup, every reconnect stacks another full set of listeners onto the
+  // long-lived `obs` singleton.
+  function handleStudioModeStateChanged (data) {
     console.log('StudioModeStateChanged', data.studioModeEnabled)
     isStudioMode = data.studioModeEnabled
     previewScene = programScene
-  })
+  }
 
-  obs.on('SceneListChanged', async (data) => {
+  function handleSceneListChanged (data) {
     console.log('SceneListChanged', data.scenes.length)
     scenes = data.scenes
-  })
+  }
 
-  obs.on('SceneCreated', async (data) => {
+  function handleSceneCreated (data) {
     console.log('SceneCreated', data)
-  })
+  }
 
-  obs.on('SceneRemoved', async (data) => {
+  // SceneListChanged (above) already fires with a fresh, complete scenes
+  // array whenever OBS's own scene-list-changed frontend event fires,
+  // which covers removal - this handler doesn't need to (and, before this
+  // fix, incorrectly tried to) also patch `scenes` itself. The previous
+  // `delete scenes[i]` mutated the array in place without a reassignment,
+  // which doesn't trigger Svelte reactivity at all and leaves a hole
+  // instead of shrinking the array - dead/buggy code that happened not to
+  // matter in practice because SceneListChanged's own reassignment
+  // superseded it anyway.
+  function handleSceneRemoved (data) {
     console.log('SceneRemoved', data)
-    for (let i = 0; i < scenes.length; i++) {
-      if (scenes[i].sceneName === data.sceneName) {
-        delete scenes[i]
-      }
-    }
-  })
+  }
 
-  obs.on('SceneNameChanged', async (data) => {
+  function handleSceneNameChanged (data) {
     console.log('SceneNameChanged', data)
     for (let i = 0; i < scenes.length; i++) {
       if (scenes[i].sceneName === data.oldSceneName) {
@@ -63,16 +74,34 @@
     }
     // Rename in sceneIcons
     sceneIcons[data.sceneName] = sceneIcons[data.oldSceneName]
-  })
+  }
 
-  obs.on('CurrentProgramSceneChanged', (data) => {
+  function handleCurrentProgramSceneChanged (data) {
     console.log('CurrentProgramSceneChanged', data)
     programScene = data.sceneName || ''
-  })
+  }
 
-  obs.on('CurrentPreviewSceneChanged', async (data) => {
+  function handleCurrentPreviewSceneChanged (data) {
     console.log('CurrentPreviewSceneChanged', data)
     previewScene = data.sceneName
+  }
+
+  obs.on('StudioModeStateChanged', handleStudioModeStateChanged)
+  obs.on('SceneListChanged', handleSceneListChanged)
+  obs.on('SceneCreated', handleSceneCreated)
+  obs.on('SceneRemoved', handleSceneRemoved)
+  obs.on('SceneNameChanged', handleSceneNameChanged)
+  obs.on('CurrentProgramSceneChanged', handleCurrentProgramSceneChanged)
+  obs.on('CurrentPreviewSceneChanged', handleCurrentPreviewSceneChanged)
+
+  onDestroy(() => {
+    obs.off('StudioModeStateChanged', handleStudioModeStateChanged)
+    obs.off('SceneListChanged', handleSceneListChanged)
+    obs.off('SceneCreated', handleSceneCreated)
+    obs.off('SceneRemoved', handleSceneRemoved)
+    obs.off('SceneNameChanged', handleSceneNameChanged)
+    obs.off('CurrentProgramSceneChanged', handleCurrentProgramSceneChanged)
+    obs.off('CurrentPreviewSceneChanged', handleCurrentPreviewSceneChanged)
   })
 
   function sceneClicker (scene) {
@@ -98,7 +127,7 @@
   class:with-icon={buttonStyle === 'icon'}
   >
   {#if editable}
-    {#each scenes.reverse() as scene}
+    {#each [...scenes].reverse() as scene}
     <li>
       <!-- svelte-ignore a11y-label-has-associated-control -->
       <label class="label">Name</label>

--- a/src/SourceButton.svelte
+++ b/src/SourceButton.svelte
@@ -44,6 +44,16 @@
   button.program {
     background-color: #f14668;
   }
+  /* isProgram and isPreview aren't mutually exclusive (this scene is both
+     live AND currently previewed at once - a normal state right after a
+     Studio Mode transition, since Preview doesn't change on its own).
+     Without this, .program's rule (declared later, same specificity) simply
+     wins the cascade and silently drops the "also previewed" cue - this
+     compound selector gives the combined state its own distinct look
+     instead. */
+  button.program.preview {
+    background: linear-gradient(135deg, #f14668 50%, #00d1b2 50%);
+  }
   button:not(.title) {
     padding: 0;
     width: 192px;


### PR DESCRIPTION
- ProgramPreview.svelte: guard getScreenshot() against overlapping calls (it's driven by both a 1s interval and a reactive trigger on every scene change) and fetch program/preview screenshots in parallel instead of sequentially - previously a slow/stale response could land after a newer one and leave the displayed image frozen. Also add colored Program/Preview pane labels+borders and clean up its obs.on() listeners on destroy (were leaking on every reconnect).
- SceneSwitcher.svelte: same obs.on() cleanup; remove a dead SceneRemoved handler that mutated the scenes array with delete (no-op for Svelte reactivity, already superseded by SceneListChanged); stop mutating the scenes array in place via .reverse() in the editable-mode template.
- SourceButton.svelte: give the combined "both live and previewed" state (normal right after a Studio Mode transition) its own visual treatment - previously the two CSS classes had equal specificity and one silently won, hiding the "also previewed" cue.